### PR TITLE
Just 'class'. It's cleaner.

### DIFF
--- a/src/littletest.hpp
+++ b/src/littletest.hpp
@@ -348,7 +348,7 @@ class test_base;
 
 std::vector<test_base*> auto_test_vector;
 
-struct test_runner
+class test_runner
 {
     public:
         test_runner() :


### PR DESCRIPTION
All the library uses classes, and access specifiers for both
methods/attributes and inheritance are explicit. I don't see any reason for
using struct instead of class here.
